### PR TITLE
Fix path for logo in GameSelect

### DIFF
--- a/src/features/dialog-manager/dialogs/game-select/index.jsx
+++ b/src/features/dialog-manager/dialogs/game-select/index.jsx
@@ -15,7 +15,7 @@ const GameSelect = ({ mainGameDialog, endlessGameDialog, loadGame }) => {
         <Dialog>
             <span className="flex-row game-select__title align-center">
                 <img
-                    src="/logo-no-bg.png"
+                    src="logo-no-bg.png"
                     alt="React RPG: 2e"
                     style={{ width: 64, height: 64, marginRight: 8 }}
                 />


### PR DESCRIPTION
## Summary
- reference `logo-no-bg.png` without a leading slash so it loads correctly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6fe2394c83248b375d6aac16b680