### PR TITLE
Add MapHeader component and tests

### DIFF
--- a/src/__tests__/components/map-header.test.jsx
+++ b/src/__tests__/components/map-header.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MapHeader from '../../components/map-header';
+
+describe('MapHeader', () => {
+  test('shows brick realm for floor 1', () => {
+    render(<MapHeader currentFloor={1} />);
+    expect(screen.getByText('The Brick Realm')).toBeInTheDocument();
+    expect(screen.getByText('Sturdy stone walls surround you.')).toBeInTheDocument();
+    expect(screen.getByTestId('map-header').className).toMatch(/theme-brick/);
+  });
+
+  test('shows ornate realm for floor 35', () => {
+    render(<MapHeader currentFloor={35} />);
+    expect(screen.getByText('The Ornate Realm')).toBeInTheDocument();
+    expect(screen.getByText('Lavishly decorated halls gleam here.')).toBeInTheDocument();
+    expect(screen.getByTestId('map-header').className).toMatch(/theme-ornate/);
+  });
+
+  test('shows purple realm for floor 70', () => {
+    render(<MapHeader currentFloor={70} />);
+    expect(screen.getByText('The Amethyst Realm')).toBeInTheDocument();
+    expect(screen.getByText('A faint purple glow emanates from the walls.')).toBeInTheDocument();
+    expect(screen.getByTestId('map-header').className).toMatch(/theme-purple/);
+  });
+});

--- a/src/components/map-header/index.jsx
+++ b/src/components/map-header/index.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import './styles.scss';
+
+const REALMS = [
+  {
+    min: 1,
+    max: 29,
+    name: 'The Brick Realm',
+    description: 'Sturdy stone walls surround you.',
+    theme: 'theme-brick',
+  },
+  {
+    min: 30,
+    max: 59,
+    name: 'The Ornate Realm',
+    description: 'Lavishly decorated halls gleam here.',
+    theme: 'theme-ornate',
+  },
+  {
+    min: 60,
+    max: 89,
+    name: 'The Amethyst Realm',
+    description: 'A faint purple glow emanates from the walls.',
+    theme: 'theme-purple',
+  },
+  {
+    min: 90,
+    max: Infinity,
+    name: 'The Incan Realm',
+    description: 'Ancient stonework dark as night.',
+    theme: 'theme-inca-dark',
+  },
+];
+
+export default function MapHeader({ currentFloor }) {
+  const realm = REALMS.find(r => currentFloor >= r.min && currentFloor <= r.max) || REALMS[REALMS.length - 1];
+  const { name, description, theme } = realm;
+  return (
+    <div className={`map-header ${theme}`} data-testid="map-header">
+      <h1>{name}</h1>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+export { REALMS };

--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -1,0 +1,4 @@
+.map-header {
+  text-align: center;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary
- add `MapHeader` component for displaying realm info
- create tests to verify realm name/description and theme classes

## Testing
- `yarn test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a3e9efc8324956b12924a2a0d6d