### PR TITLE
Add MapHeader component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
 
 import DialogManager from './features/dialog-manager';
 import FloorCounter from './components/floor-counter';
+import MapHeader from './components/MapHeader';
 import Footer from './components/footer';
 import GameMenus from './features/game-menus';
 import World from './features/world';
@@ -28,6 +29,7 @@ const App = ({ appState, world, dialog }) => {
 
     const { sideMenu, journalSideMenu } = appState;
     const { gameMode, floorNum, currentMap } = world;
+    const currentFloorId = currentMap || floorNum;
     const { gameStart, gameOver, gameRunning, journalSideMenuOpen } = dialog;
 
     const disableJournal =
@@ -59,6 +61,8 @@ const App = ({ appState, world, dialog }) => {
                                 <Tutorial />
                                 <Abilities />
                                 <Spellbook />
+
+                                <MapHeader currentFloor={currentFloorId} />
 
                                 {gameMode === 'endless' ? (
                                     <FloorCounter floor={floorNum} />
@@ -100,6 +104,8 @@ const App = ({ appState, world, dialog }) => {
                             <Tutorial />
                             <Abilities />
                             <Spellbook />
+
+                            <MapHeader currentFloor={currentFloorId} />
 
                             {gameMode === 'endless' ? (
                                 <FloorCounter floor={floorNum} />

--- a/src/components/MapHeader.jsx
+++ b/src/components/MapHeader.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import realms from '../data/realms';
+
+import './map-header/styles.scss';
+
+const MapHeader = ({ currentFloor }) => {
+    const floorKey = String(currentFloor);
+    const realm = realms.find(r => r.floors.includes(floorKey));
+
+    if (!realm) return null;
+
+    return (
+        <div className={`map-header ${realm.themeClass || ''}`.trim()}>
+            <h2>{realm.name}</h2>
+            {realm.description && <p>{realm.description}</p>}
+        </div>
+    );
+};
+
+export default MapHeader;

--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -1,0 +1,37 @@
+.map-header {
+    position: absolute;
+    top: 4px;
+    left: 0;
+    right: 0;
+
+    width: fit-content;
+    margin: auto;
+    padding: 4px 10px;
+
+    text-align: center;
+    font-size: 24px;
+    font-weight: 600;
+
+    background: rgba(173, 173, 173, 0.5);
+    border-radius: 7px;
+}
+
+.dungeon-theme {
+    color: var(--gray);
+}
+
+.cave-theme {
+    color: var(--blue);
+}
+
+.ruins-theme {
+    color: var(--orange);
+}
+
+.catacomb-theme {
+    color: var(--purple);
+}
+
+.keep-theme {
+    color: var(--light-red);
+}

--- a/src/data/realms.js
+++ b/src/data/realms.js
@@ -1,0 +1,34 @@
+const realms = [
+    {
+        name: 'Dungeon Depths',
+        floors: ['1_1', '1_2', '1_3', '1_4', '1_5'],
+        themeClass: 'dungeon-theme',
+        description: 'Dark corridors filled with the stench of decay.'
+    },
+    {
+        name: 'Crystal Caves',
+        floors: ['2_1', '2_2', '2_3', '2_4', '2_5'],
+        themeClass: 'cave-theme',
+        description: 'Glittering caverns illuminated by glowing fungi.'
+    },
+    {
+        name: 'Ancient Ruins',
+        floors: ['3_1', '3_2', '3_3', '3_4', '3_5'],
+        themeClass: 'ruins-theme',
+        description: 'Forgotten halls echoing with old magic.'
+    },
+    {
+        name: 'Dark Catacombs',
+        floors: ['4_1', '4_2', '4_3', '4_4', '4_5'],
+        themeClass: 'catacomb-theme',
+        description: 'Twisting tunnels lined with grim remains.'
+    },
+    {
+        name: 'Forsaken Keep',
+        floors: ['5_1', '5_2', '5_3', '5_4', '5_5'],
+        themeClass: 'keep-theme',
+        description: 'The heart of the dungeon and home to its master.'
+    }
+];
+
+export default realms;


### PR DESCRIPTION
## Summary
- introduce realm definitions with names and descriptions
- create MapHeader component with styling
- display the current realm in App

## Testing
- `npx jest` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a3756348324a66306dc44c8e23b