### PR TITLE
Fix missing closing brace

### DIFF
--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -28,6 +28,7 @@
 .realm-caverns .map-header__title {
   background: #1a233a;
   color: var(--gray);
+}
 
 .map-header {
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import { VitePWA } from 'vite-plugin-pwa';
+const { defineConfig } = require('vite');
+const react = require('@vitejs/plugin-react');
+const { VitePWA } = require('vite-plugin-pwa');
 
 // https://vitejs.dev/config/
-export default defineConfig({
+module.exports = defineConfig({
     base: './',
     optimizeDeps: {
         esbuildOptions: {


### PR DESCRIPTION
## Summary
- fix Sass compilation by closing `.realm-caverns` style block
- switch Vite config to CommonJS export so Node can load it

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684f7f1346a08324adeea084ca09b644