### PR TITLE
Add typographic scale and adjust colors

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,8 @@
 html {
     --red: #650501;
     --green: #258000;
-    --gray: #adadad;
+    /* lighter text color for better contrast */
+    --gray: #e0e0e0;
     --medium-gray: #292929;
     --dark-gray: #0f0f0f;
     --blue: #006fd7;
@@ -9,6 +10,14 @@ html {
     --light-red: #ff593b;
     --purple: #b666d2;
     --transparent: rgba(0, 0, 0, 0);
+
+    /* typographic scale */
+    --base-size: 1rem;
+    --scale-ratio: 1.25;
+    --type-small: calc(var(--base-size) / var(--scale-ratio));
+    --type-base: var(--base-size);
+    --type-large: calc(var(--base-size) * var(--scale-ratio));
+    --type-xlarge: calc(var(--type-large) * var(--scale-ratio));
 }
 
 body {
@@ -17,16 +26,18 @@ body {
     /* default text color */
     color: var(--gray);
     /* default font */
-    font-family: Montserrat, Roboto, sans-serif;
+    font-family: 'Montserrat', Roboto, sans-serif;
     font-weight: 400;
-    font-size: 20px;
+    font-size: var(--type-base);
+    line-height: 1.5;
     text-transform: uppercase;
 }
 
 button {
-    font-size: 20px;
+    font-size: var(--type-base);
     font-family: Montserrat;
     text-transform: uppercase;
+    letter-spacing: 0.02em;
 
     color: var(--gray);
     outline-color: var(--gray);
@@ -98,4 +109,28 @@ a {
     border: 1px solid;
     border-radius: 2px;
     color: var(--gray);
+}
+
+h1 {
+    font-size: var(--type-xlarge);
+    line-height: 1.2;
+}
+
+h2 {
+    font-size: var(--type-large);
+    line-height: 1.3;
+}
+
+h3 {
+    font-size: var(--type-base);
+    line-height: 1.3;
+}
+
+p {
+    font-size: var(--type-base);
+    line-height: 1.5;
+}
+
+small {
+    font-size: var(--type-small);
 }


### PR DESCRIPTION
## Summary
- introduce CSS custom properties for a type scale
- update body and button styles to use the new scale
- style headings with the scale and improve contrast

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f8029dde8832485e04abbf616f594