### PR TITLE
Fix map header overlap

### DIFF
--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -33,16 +33,17 @@
 .map-header {
 
     position: absolute;
-    top: 4px;
+    bottom: 4px;
     left: 0;
     right: 0;
+    top: auto;
 
     width: fit-content;
     margin: auto;
     padding: 4px 10px;
 
     text-align: center;
-    font-size: 24px;
+    font-size: 18px;
     font-weight: 600;
 
     background: rgba(173, 173, 173, 0.5);


### PR DESCRIPTION
## Summary
- position map header at the bottom of the viewport
- shrink the map header font size

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_684f83a969a08324b7d9de7d0d32f97f