### PR TITLE
Add data-testid and update MapHeader tests

### DIFF
--- a/src/__tests__/components/map-header.test.jsx
+++ b/src/__tests__/components/map-header.test.jsx
@@ -1,26 +1,16 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import MapHeader from '../../components/map-header';
+import MapHeader from '../../components/MapHeader';
+import realms from '../../data/realms';
 
 describe('MapHeader', () => {
-  test('shows brick realm for floor 1', () => {
-    render(<MapHeader currentFloor={1} />);
-    expect(screen.getByText('The Brick Realm')).toBeInTheDocument();
-    expect(screen.getByText('Sturdy stone walls surround you.')).toBeInTheDocument();
-    expect(screen.getByTestId('map-header').className).toMatch(/theme-brick/);
-  });
-
-  test('shows ornate realm for floor 35', () => {
-    render(<MapHeader currentFloor={35} />);
-    expect(screen.getByText('The Ornate Realm')).toBeInTheDocument();
-    expect(screen.getByText('Lavishly decorated halls gleam here.')).toBeInTheDocument();
-    expect(screen.getByTestId('map-header').className).toMatch(/theme-ornate/);
-  });
-
-  test('shows purple realm for floor 70', () => {
-    render(<MapHeader currentFloor={70} />);
-    expect(screen.getByText('The Amethyst Realm')).toBeInTheDocument();
-    expect(screen.getByText('A faint purple glow emanates from the walls.')).toBeInTheDocument();
-    expect(screen.getByTestId('map-header').className).toMatch(/theme-purple/);
+  test('shows realm details for various floors', () => {
+    realms.slice(0, 3).forEach((realm) => {
+      const floor = realm.floors[0];
+      render(<MapHeader currentFloor={floor} />);
+      expect(screen.getByText(realm.name)).toBeInTheDocument();
+      expect(screen.getByText(realm.description)).toBeInTheDocument();
+      expect(screen.getByTestId('map-header').className).toMatch(new RegExp(realm.themeClass));
+    });
   });
 });

--- a/src/components/MapHeader.jsx
+++ b/src/components/MapHeader.jsx
@@ -4,17 +4,17 @@ import realms from '../data/realms';
 import './map-header/styles.scss';
 
 const MapHeader = ({ currentFloor }) => {
-    const floorKey = String(currentFloor);
-    const realm = realms.find(r => r.floors.includes(floorKey));
+  const floorKey = String(currentFloor);
+  const realm = realms.find((r) => r.floors.includes(floorKey));
 
-    if (!realm) return null;
+  if (!realm) return null;
 
-    return (
-        <div className={`map-header ${realm.themeClass || ''}`.trim()}>
-            <h2>{realm.name}</h2>
-            {realm.description && <p>{realm.description}</p>}
-        </div>
-    );
+  return (
+    <div className={`map-header ${realm.themeClass || ''}`.trim()} data-testid="map-header">
+      <h2>{realm.name}</h2>
+      {realm.description && <p>{realm.description}</p>}
+    </div>
+  );
 };
 
 export default MapHeader;


### PR DESCRIPTION
## Summary
- expose `data-testid="map-header"` from MapHeader component
- rewrite map-header tests to use `realms.js` data

## Testing
- `npx prettier -w src/components/MapHeader.jsx src/__tests__/components/map-header.test.jsx`
- `npx eslint src/components/MapHeader.jsx src/__tests__/components/map-header.test.jsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_684f86edb27c8324afe1a12ba6436412