### PR TITLE
Fix wall type detection

### DIFF
--- a/src/features/map/index.jsx
+++ b/src/features/map/index.jsx
@@ -82,7 +82,13 @@ const MapRow = props => {
 function getWallType(tiles) {
     for (let i = 0; i < tiles.length; i++) {
         for (let j = 0; j < tiles[i].length; j++) {
-            if (typeof (tiles[i][j] === 'number') && tiles[i][j].value === 5)
+            if (typeof tiles[i][j] === 'number' && tiles[i][j] === 5)
+                return tiles[i][j];
+            if (
+                typeof tiles[i][j] === 'object' &&
+                tiles[i][j] !== null &&
+                tiles[i][j].value === 5
+            )
                 return tiles[i][j].value;
         }
     }


### PR DESCRIPTION
## Summary
- fix wall tile type check when determining padding tile sprite

## Testing
- `npx eslint src/features/map/index.jsx` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684f86eb06c48324b9ada2ad1c4813dd