### PR TITLE
Shrink MapHeader text

### DIFF
--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -50,6 +50,11 @@
     border-radius: 7px;
 }
 
+.map-header h2,
+.map-header p {
+    font-size: var(--type-small);
+}
+
 .dungeon-theme {
     color: var(--gray);
 }


### PR DESCRIPTION
## Summary
- adjust MapHeader styles so header and description use the small type size

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684f899c610c83248a7187309261b289