### PR TITLE
Shrink map header title

### DIFF
--- a/src/components/map-header/styles.scss
+++ b/src/components/map-header/styles.scss
@@ -50,6 +50,7 @@
     border-radius: 7px;
 }
 
+.map-header h1,
 .map-header h2,
 .map-header p {
     font-size: var(--type-small);


### PR DESCRIPTION
## Summary
- tweak map-header styles so h1 text is tiny

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684f8b8838d08324ba090a70655fe679